### PR TITLE
Drop support for PHP 8.2/8.3 and Laravel 10/11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [12.*, 13.*]
         os: [ubuntu-latest]
         coverage: [none]
         include:
           - php: 8.5
-            laravel: 12.*
+            laravel: 13.*
             os: ubuntu-latest
             coverage: xdebug
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ A Laravel package for reporting server and environment information such as PHP v
 
 ## Requirements
 
-- PHP 8.2, 8.3, or 8.4
-- Laravel 10.x, 11.x, or 12.x
+- PHP 8.4 or 8.5
+- Laravel 12.x or 13.x
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         }
     ],
     "require": {
-        "php": "^8.2 || ^8.3 || ^8.4",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0"
+        "php": "^8.4",
+        "illuminate/support": "^12.0 || ^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "laravel/pint": "^1.21",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^12.0",


### PR DESCRIPTION
This PR updates the package to require PHP 8.4+ and Laravel 12.x/13.x, dropping support for older versions.

## Summary
Modernizes the package's minimum version requirements to focus on the latest stable releases of PHP and Laravel, allowing us to leverage newer language features and framework capabilities.

## Key changes
- **PHP requirement**: Updated from `^8.2 || ^8.3 || ^8.4` to `^8.4` (drops PHP 8.2 and 8.3 support)
- **Laravel requirement**: Updated from `^10.0 || ^11.0 || ^12.0` to `^12.0 || ^13.0` (drops Laravel 10 and 11 support)
- **Testbench requirement**: Updated from `^8.0 || ^9.0 || ^10.0` to `^10.0 || ^11.0` to align with supported Laravel versions
- **CI matrix**: Updated GitHub Actions workflow to test against PHP 8.4 and 8.5 with Laravel 12.x and 13.x
- **Documentation**: Updated README.md to reflect new version requirements

## Notes
This is a breaking change for users on older PHP or Laravel versions. They will need to upgrade their environments to use this version of the package.

https://claude.ai/code/session_01Qe7ZpV8K5zfpXKRefoCyz9